### PR TITLE
Fix Synergy WS URL fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ docker-compose up --build
 
 The web interface will be available at <http://localhost:3000> and streams
 real-time `meltdownFrac` values under the **Synergy Field Monitor** tab.
+
+If the `NEXT_PUBLIC_SFM_WS` environment variable is not set, the monitor
+automatically falls back to `window.location` to locate the WebSocket backend.

--- a/components/sfm/SynergyFieldMonitor.tsx
+++ b/components/sfm/SynergyFieldMonitor.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import Meter from "./Meter";
 import { useStream } from "./hooks";
 
-const WS_URL = process.env.NEXT_PUBLIC_SFM_WS || "ws://localhost:8000/ws";
+const WS_URL =
+  process.env.NEXT_PUBLIC_SFM_WS ??
+  `${window.location.origin.replace(/^http/, "ws")}/ws`;
 
 export default function SynergyFieldMonitor() {
   const tick = useStream(WS_URL);


### PR DESCRIPTION
## Summary
- let `SynergyFieldMonitor` default WebSocket URL to the browser location when the environment variable is unset
- document the automatic fallback in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d4ab23a70833282285a5bf3be4dbe