### PR TITLE
Render split with Docker backend & health-check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+**/__pycache__/
+node_modules/
+.git/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Set **both** environment variables:
 
 - `RIL_ENTROPY_BUDGET` on the backend (e.g. `30000`)
 - `NEXT_PUBLIC_CHAT_WS` on the frontend
- wss://mpfst-backend.onrender.com/brain/ws/chat  ← update after the backend URL changes
+The site is now deployed as **two Render services** (frontend & backend).  
+`NEXT_PUBLIC_CHAT_WS` must point to  
+`wss://mpfst-backend.onrender.com/brain/ws/chat`
 
 If the chat panel simply echoes your input the VM binary was not copied
 successfully – redeploy the backend and check container logs for `RIL-VM ready`.

--- a/render.yaml
+++ b/render.yaml
@@ -1,14 +1,32 @@
 services:
+  # ——— FRONTEND (Next.js) ————————————————————————————
+  - type: web
+    name: mpfst-frontend
+    env: node
+    plan: pro
+    rootDir: .
+    buildCommand: npm ci && npm run build
+    startCommand: npm start
+    envVars:
+      - key: NEXT_PUBLIC_SFM_WS
+        value: wss://mpfst-backend.onrender.com/ws
+      - key: NEXT_PUBLIC_CHAT_WS
+        value: wss://mpfst-backend.onrender.com/brain/ws/chat
+
+  # ——— BACKEND (Docker, FastAPI + RIL‑VM) ————————————
   - type: web
     name: mpfst-backend
     env: docker
-    plan: pro              # needs ≥2\u00a0GB RAM for Llama-2-7B-Q4
     dockerfilePath: ./sfm/backend/Dockerfile
-    dockerContext: .       # repo root so ‘sfm/’ package is copied
+    dockerContext: .
+    plan: pro
+    healthCheckPath: /version
     envVars:
+      - key: RIL_ENTROPY_BUDGET
+        value: "30000"
+      - key: SFM_UPDATE_SEC
+        value: "60"
       - key: ACLED_EMAIL
         fromEnvVar: ACLED_EMAIL
       - key: ACLED_API_TOKEN
         fromEnvVar: ACLED_API_TOKEN
-      - key: RIL_ENTROPY_BUDGET
-        value: "30000"

--- a/sfm/backend/Dockerfile
+++ b/sfm/backend/Dockerfile
@@ -8,12 +8,12 @@ COPY . .
 # copy brain runtime (now inside context)
 COPY brain/ /app/brain/
 ENV RIL_VM_BIN=/app/brain/bin/rilvm
-# fetch model at build-time and download VM
-RUN mkdir -p /app/brain/bin \
-    && curl -L --retry 5 -o /app/brain/bin/rilvm \
-      https://github.com/your-org/kaicore/releases/download/v7.0.0/rilvm-linux-x86_64 \
-    && chmod +x /app/brain/bin/rilvm \
-    && bash /app/brain/setup_model.sh
-# simple health-check – fails if binary missing
-HEALTHCHECK CMD test -x /app/brain/bin/rilvm
+# Download real RIL-VM binary if not staged by CI layer
+RUN [ -x "$RIL_VM_BIN" ] || \
+    (curl -L --retry 5 -o "$RIL_VM_BIN" \
+       https://github.com/your-org/kaicore/releases/download/v7.0.0/rilvm-linux-x86_64 \
+     && chmod +x "$RIL_VM_BIN") \
+ && bash /app/brain/setup_model.sh
+# Health-check used by Render
+HEALTHCHECK CMD curl -f http://localhost:8000/version || exit 1
 CMD ["uvicorn", "sfm.backend.app:api", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- place `__init__` markers so Python packages are importable
- add `.dockerignore`
- harden the backend Dockerfile and add HTTP health check
- split Render config into frontend and backend services
- clarify README about Render setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*
- `npm test` *(fails: JSX element implicitly has type 'any' errors)*

------
https://chatgpt.com/codex/tasks/task_e_68536695d0e4833288359e4cb9ab36c1