### PR TITLE
Fix imports in chat router

### DIFF
--- a/sfm/backend/chat_router.py
+++ b/sfm/backend/chat_router.py
@@ -13,11 +13,10 @@ from pathlib import Path
 from typing import AsyncGenerator
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sfm.backend.brain.llama_runner import LlamaRunner
 
-# thin wrapper you already added in brain/llama_runner.py
-from .brain.llama_runner import LlamaRunner
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 


### PR DESCRIPTION
## Summary
- import `StreamingResponse` for SSE endpoints
- remove duplicate `LlamaRunner` import

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6853bd0010588332bf72b1c30a8414d7