### PR TITLE
Expose chat API under /brain/ws/chat

### DIFF
--- a/sfm/backend/app.py
+++ b/sfm/backend/app.py
@@ -19,8 +19,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Mount the /chat router
-app.include_router(chat_router)
+# Mount the chat router under /brain/ws
+app.include_router(chat_router, prefix="/brain/ws")
 
 # ------------------------------------------
 # REST API ROUTES

--- a/sfm/backend/chat_router.py
+++ b/sfm/backend/chat_router.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from sfm.backend.brain.llama_runner import LlamaRunner
 
 
-router = APIRouter(prefix="/chat", tags=["chat"])
+router = APIRouter(tags=["chat"])
 
 # ---------------------------------------------------------------------------#
 # helpers                                                                    #


### PR DESCRIPTION
## Summary
- include `chat_router` under `/brain/ws`
- drop internal prefix from `chat_router`

## Testing
- `pip install -r sfm/backend/requirements.txt`
- `npm ci`
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bdd4540883329e3af9fa5ab853ab