### PR TITLE
stream actual synergy metrics

### DIFF
--- a/sfm/backend/app.py
+++ b/sfm/backend/app.py
@@ -78,6 +78,7 @@ def synergy(
 
 @app.websocket("/ws")
 async def websocket_synergy(websocket: WebSocket):
+    """Stream synergy metrics every ``SFM_UPDATE_SEC`` seconds (default 60)."""
     await websocket.accept()
     try:
         update = int(os.getenv("SFM_UPDATE_SEC", "60"))


### PR DESCRIPTION
## Summary
- show how often synergy metrics update with docstring

## Testing
- `npm test` *(fails: Cannot find module 'react', etc.)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_6853c325dfc483328646d800afe43f08