### PR TITLE
Fix backend module path

### DIFF
--- a/sfm/backend/Dockerfile
+++ b/sfm/backend/Dockerfile
@@ -53,6 +53,9 @@ RUN set -eux; \
     fi; \
     bash brain/setup_model.sh
 
+# Return to project root so Python can resolve the `sfm` package
+WORKDIR /app
+
 # ────────────────────────────────────────────────
 # 5 · Health‑check & launch
 # ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- reset working directory after downloading RIL-VM so that `uvicorn` can locate the `sfm` package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b16b9d1888332a35a80ba63cc5e1c